### PR TITLE
Convert the unclosed block SyntaxError into a UserWarning

### DIFF
--- a/src/ducktools/pep723parser.py
+++ b/src/ducktools/pep723parser.py
@@ -108,10 +108,14 @@ class PEP723Parser:
         for line in iterable_src:
             if in_block:
                 if not line.startswith("#"):
-                    raise SyntaxError(
-                        f"Block {block_name!r} not closed correctly. "
+                    warnings.warn(
+                        f"Potential unclosed block {block_name!r} detected. "
                         f"A '# ///' block is needed to indicate the end of the block."
                     )
+                    # Reset
+                    in_block = False
+                    block_name, block_data = None, []
+                    continue
 
                 line = _removeprefix(_removeprefix(line, "#"), " ")
                 if line.strip() == "///":
@@ -146,8 +150,8 @@ class PEP723Parser:
                         in_block = True
 
         if in_block:
-            raise SyntaxError(
-                f"Block {block_name!r} not closed correctly. "
+            warnings.warn(
+                f"Potential unclosed block {block_name!r} detected. "
                 f"A '# ///' block is needed to indicate the end of the block."
             )
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -14,6 +14,7 @@ def get_parser(path, parse_type):
         return PEP723Parser.from_path(path)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("parser_type", ["string", "path"])
 @pytest.mark.parametrize("module_name", dir(test_data))
 def test_compliance(parser_type, module_name):
@@ -22,7 +23,7 @@ def test_compliance(parser_type, module_name):
     try:
         metadata = parser.metadata_blocks
     except Exception as e:
-        assert module.is_error or module.strict_error
+        assert module.is_error
         assert type(e) is type(module.exact_error) and e.args == module.exact_error.args
     else:
         assert metadata == module.output

--- a/tests/test_data/basic_pep_example.py
+++ b/tests/test_data/basic_pep_example.py
@@ -29,5 +29,4 @@ output = {
 is_error = False
 
 # Internal
-strict_error = False
 exact_error = None

--- a/tests/test_data/multiple_blocks_joined.py
+++ b/tests/test_data/multiple_blocks_joined.py
@@ -29,5 +29,4 @@ output = {
 is_error = False
 
 # Internals
-strict_error = False
 exact_error = None

--- a/tests/test_data/multiple_closing_lines.py
+++ b/tests/test_data/multiple_closing_lines.py
@@ -19,5 +19,4 @@ output = {
 is_error = False
 
 # Internals
-strict_error = False
 exact_error = None

--- a/tests/test_data/multiple_opening_lines.py
+++ b/tests/test_data/multiple_opening_lines.py
@@ -21,5 +21,4 @@ output = {
 is_error = False
 
 # Internals
-strict_error = False
 exact_error = None

--- a/tests/test_data/no_block.py
+++ b/tests/test_data/no_block.py
@@ -4,5 +4,4 @@ output = {}
 is_error = False
 
 # Internal
-strict_error = False
 exact_error = None

--- a/tests/test_data/repeated_block_error.py
+++ b/tests/test_data/repeated_block_error.py
@@ -20,5 +20,4 @@ output = {}
 is_error = True
 
 # Internal
-strict_error = True
 exact_error = ValueError(f"Multiple 'pyproject' blocks found.")

--- a/tests/test_data/unclosed_block_eof.py
+++ b/tests/test_data/unclosed_block_eof.py
@@ -6,11 +6,7 @@ output = {}
 is_error = False
 
 # Internal
-strict_error = True
-exact_error = SyntaxError(
-    f"Block 'pyproject' not closed correctly. "
-    f"A '# ///' block is needed to indicate the end of the block."
-)
+exact_error = None
 
 
 # /// pyproject

--- a/tests/test_data/unclosed_block_example.py
+++ b/tests/test_data/unclosed_block_example.py
@@ -11,8 +11,4 @@ output = {}
 is_error = False
 
 # Internal
-strict_error = True
-exact_error = SyntaxError(
-    f"Block 'pyproject' not closed correctly. "
-    f"A '# ///' block is needed to indicate the end of the block."
-)
+exact_error = None

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -77,13 +77,13 @@ class TestRaises:
     def test_block_not_closed(self):
         test_file = example_folder / "pep-723-sample-noclose.py"
         parser = PEP723Parser.from_path(test_file)
-        with pytest.raises(SyntaxError):
+        with pytest.warns(UserWarning):
             _ = parser.script_dependencies
 
     def test_block_not_closed_eof(self):
         test_file = example_folder / "pep-723-sample-noclose-eof.py"
         parser = PEP723Parser.from_path(test_file)
-        with pytest.raises(SyntaxError):
+        with pytest.warns(UserWarning):
             _ = parser.script_dependencies
 
     def test_repeated_block(self):


### PR DESCRIPTION
This matches the behaviour of the regex. But also emits a warning because it's potentially a mistake.