### PR TITLE
API changes and Parsing rules tightening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ scratch/
 build/
 _build/
 dist/
+htmlcov/
 
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Lazy parser for PEP723 embedded TOML data.
 ## Example ##
 
 ```python
-from ducktools.pep723parser import EmbeddedMetadataParser
+from ducktools.pep723parser import metadata_from_path
 from pprint import pprint
 
-parser = EmbeddedMetadataParser.from_path("examples/pep-723-sample.py")
+metadata = metadata_from_path("examples/pep-723-sample.py")
 
-pprint(parser.script_dependencies)
+pprint(metadata.run_requirements)
 ```
 
 Output:
@@ -24,52 +24,39 @@ Output:
 To create a PEP723Parser there are 2 class methods provided
 
 ```python
+from pathlib import Path
+
+from ducktools.pep723parser import (
+    metadata_from_path,
+    metadata_from_string,
+)
+
+src_path = Path("examples/pep-723-sample.py")
+
 # Create a parser from a path to a source file
-parser = PEP723Parser.from_path(src_path, encoding="utf-8")
+metadata = metadata_from_path(src_path, encoding="utf-8")
 
 # Create a parser from source code as a string
-parser = PEP723Parser.from_source(src)
-```
-
-The resulting parser objects provide the following methods.
-
-```python
-# iter_raw_metadata_blocks to iterate over the metadata blocks
-# yield the block name (type) and its contents as tuples
-# Note: this will raise a ValueError if a block with the same
-#       block_name is encountered multiple times.
-parser.iter_raw_metadata_blocks()
-
-# Scan through the file and return the text of the first
-# metadata block encountered with the specified block_name
-# raise a KeyError if not found.
-parser.get_first_metadata_block("pyproject")
+metadata = metadata_from_string(src_path.read_text())
 
 # Get all metadata blocks and unprocessed text as a dict
-parser.metadata_blocks
+metadata.blocks
 
-# Get the unprocessed pyproject text or raise a KeyError 
+# Return the unprocessed pyproject block text or None 
 # if there is no block
-parser.get_pyproject_raw()
-
-# Return the unprocessed pyproject text or None if there is no block
-parser.pyproject_raw
-
-# Get the pyproject block processed by tomllib/tomli
-# or raise a KeyError if there is no block
-parser.get_pyproject_toml()
+metadata.pyproject_text
 
 # Return the pyproject block processed by tomllib/tomli
-# or return None if there is no block
-parser.pyproject_toml
+# or return an empty dict if there is no block
+metadata.pyproject_toml
 
 # Return the [run] block from the pyproject block
 # requires-python and dependencies values will exist
 # as empty data even if not defined in the block
-parser.plain_script_dependencies
+metadata.run_requirements_text
 
 # Return the [run] block from the pyproject block
 # with requires-python and dependencies values processed
 # by packaging into SpecifierSet and Requirement objects
-parser.script_dependencies
+metadata.run_requirements
 ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Lazy parser for PEP723 embedded TOML data.
 ## Example ##
 
 ```python
-from ducktools.pep723parser import PEP723Parser
+from ducktools.pep723parser import EmbeddedMetadataParser
 from pprint import pprint
 
-parser = PEP723Parser.from_path("examples/pep-723-sample.py")
+parser = EmbeddedMetadataParser.from_path("examples/pep-723-sample.py")
 
 pprint(parser.script_dependencies)
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ducktools: pep723parser #
 
-Lazy parser for PEP723 embedded TOML data.
+Parser for embedded metadata in python source files 
+as defined in [PEP723](https://peps.python.org/pep-0723/).
 
 ## Example ##
 

--- a/perf/import_parse.py
+++ b/perf/import_parse.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import PEP723Parser
+from ducktools.pep723parser import EmbeddedMetadataParser
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = PEP723Parser.from_path(pth)
+data = EmbeddedMetadataParser.from_path(pth)
 
 output = data.pyproject_raw

--- a/perf/import_parse.py
+++ b/perf/import_parse.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import EmbeddedMetadataParser
+from ducktools.pep723parser import metadata_from_path
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = EmbeddedMetadataParser.from_path(pth)
+data = metadata_from_path(pth)
 
-output = data.pyproject_raw
+output = data.pyproject_text

--- a/perf/import_parse_requirements.py
+++ b/perf/import_parse_requirements.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import PEP723Parser
+from ducktools.pep723parser import EmbeddedMetadataParser
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = PEP723Parser.from_path(pth)
+data = EmbeddedMetadataParser.from_path(pth)
 
 output = data.script_dependencies

--- a/perf/import_parse_requirements.py
+++ b/perf/import_parse_requirements.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import EmbeddedMetadataParser
+from ducktools.pep723parser import metadata_from_path
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = EmbeddedMetadataParser.from_path(pth)
+data = metadata_from_path(pth)
 
-output = data.script_dependencies
+output = data.run_requirements

--- a/perf/import_parse_toml.py
+++ b/perf/import_parse_toml.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import PEP723Parser
+from ducktools.pep723parser import EmbeddedMetadataParser
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = PEP723Parser.from_path(pth)
+data = EmbeddedMetadataParser.from_path(pth)
 
 output = data.plain_script_dependencies

--- a/perf/import_parse_toml.py
+++ b/perf/import_parse_toml.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import EmbeddedMetadataParser
+from ducktools.pep723parser import metadata_from_path
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = EmbeddedMetadataParser.from_path(pth)
+data = metadata_from_path(pth)
 
-output = data.plain_script_dependencies
+output = data.run_requirements_text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.8"
 dependencies = [
     "tomli >= 1.1.0 ; python_version < '3.11'",
     "packaging >= 23.2",
-    "ducktools-lazyimporter >= 0.1.1",
+    "ducktools-lazyimporter >= 0.1.2",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",

--- a/src/ducktools/pep723parser.py
+++ b/src/ducktools/pep723parser.py
@@ -21,15 +21,6 @@ _laz = LazyImporter(
 )
 
 
-def _removeprefix(txt, prefix):
-    # Python 3.8 has no remove_prefix method on str
-    # Copied from the PEP that added it with 'self' changed to 'txt'
-    if txt.startswith(prefix):
-        return txt[len(prefix):]  # fmt: skip
-    else:
-        return txt[:]  # pragma: no cover
-
-
 # The string library imports 're' so some extra manual work here
 def _is_valid_type(txt):
     """
@@ -198,27 +189,27 @@ def _parse_metadata_iterable(iterable_src):
                 end_seen = True
 
                 # reset partial data - add this line
-                partial_block_data = [_removeprefix(line[1:], " ")]
+                partial_block_data = [line[2:]]
 
             else:
                 if line.startswith("# /// "):
                     # Possibly an unclosed block. Make note.
-                    invalid_block_name = line[5:].strip()
+                    invalid_block_name = line[6:].strip()
                     warnings_list.append(
                         f"Line {line_no}: "
                         f"New {invalid_block_name!r} block encountered before "
                         f"block {block_name!r} closed."
                     )
 
-                # Append
-                partial_block_data.append(_removeprefix(line[1:], " "))
+                # Remove '# ' or '#' prefix
+                line = line[2:] if line.startswith("# ") else line[1:]
+                partial_block_data.append(line)
         else:
             if line.startswith("#"):
                 line = line.rstrip()
 
                 if line != "# ///" and line.startswith("# /// "):
-                    line = _removeprefix(line[1:], " ")
-                    block_name = line[4:].strip()
+                    block_name = line[6:].strip()
 
                     # Fair chance people will try to call the block
                     # 'pyproject.toml', warn in that case

--- a/src/ducktools/pep723parser.py
+++ b/src/ducktools/pep723parser.py
@@ -71,10 +71,14 @@ class EmbeddedMetadata:
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
-            f"metadata={self.blocks!r}, "
+            f"blocks={self.blocks!r}, "
             f"warnings={self.warnings!r}"
             f")"
         )
+
+    def __eq__(self, other):
+        if self.__class__ is other.__class__:
+            return (self.blocks, self.warnings) == (other.blocks, other.warnings)
 
     @property
     def pyproject_text(self):

--- a/src/ducktools/pep723parser.py
+++ b/src/ducktools/pep723parser.py
@@ -1,5 +1,5 @@
 """
-Lazy PEP723 format parser.
+Embedded Python metadata format parser.
 """
 
 import sys
@@ -11,7 +11,7 @@ from ducktools.lazyimporter import LazyImporter, TryExceptImport, FromImport
 
 __version__ = "v0.0.1"
 
-# Lazily import tomllib and packaging
+# Lazily import tomllib and packaging as _laz attributes
 _laz = LazyImporter(
     [
         TryExceptImport("tomllib", "tomli", "tomllib"),
@@ -49,301 +49,224 @@ def _is_valid_type(txt):
     return all(c in valid_type for c in txt)
 
 
-class EmbeddedMetadataParser:
+class EmbeddedMetadata:
     """
-    Parse embedded metadata blocks.
-
-    This provides methods and properties to assist in handling
-    embedded metadata blocks.
-
-    get_* methods will raise a KeyError exception if the block is not found
-    properties will instead return None if the block is not found
+    Embedded metadata extracted from a python source file
     """
 
     PYTHON_VERSION_KEY = "requires-python"
     DEPENDENCIES_KEY = "dependencies"
 
-    __slots__ = ("src", "src_path", "encoding", "possible_errors")
-
-    def __init__(self, *, src=None, src_path=None, encoding="utf-8"):
-        if src and src_path:
-            raise ValueError("Provide only one of 'src' and 'src_path'")
-        elif not (src or src_path):
-            raise ValueError("Must provide one of 'src' and 'src_path'")
-
-        self.src = src
-        self.src_path = src_path
-        self.encoding = encoding
-
-        self.possible_errors = []
-
-    @classmethod
-    def from_path(cls, src_path, encoding="utf-8"):
+    def __init__(self, blocks, *, warnings=None):
         """
-        Create an EmbeddedMetadataParser instance given the path to a source file
 
-        :param src_path: path to a python source file to search for embedded metadata
-        :type src_path: str | os.PathLike
-        :param encoding: encoding to use when opening the file.
-        :type encoding: str
-        :return: EmbeddedMetadataParser instance
+        :param blocks: Metadata dict extracted from python source
+        :type blocks: dict[str, str]
+        :param warnings: Possible errors found during parsing
+        :type warnings: list[str]
         """
-        return cls(src_path=src_path, encoding=encoding)
+        self.blocks = blocks
+        self.warnings = warnings
 
-    @classmethod
-    def from_string(cls, src):
-        """
-        Create a EmbeddedMetadataParser instance given source code as a string
-
-        :param src: source code to search for embedded metadata.
-        :type src: str
-        :return: EmbeddedMetadataParser instance
-        """
-        return cls(src=src)
-
-    def _parse_source_blocks(self, iterable_src):
-        """
-        Iterate over source and yield raw toml source as the blocks occur.
-
-        :param iterable_src: an iterable of source code: eg an open file
-        :type iterable_src: Iterable[str]
-        :yield: tuples of (block_name, block_data)
-        :ytype: tuple[str, str]
-        """
-        in_block = False
-        block_name = None
-        block_data = []
-
-        consumed_blocks = set()
-
-        # Reset possible error block to avoid repetition
-        self.possible_errors = []
-
-        for line in iterable_src:
-            if in_block:
-                if not (line.rstrip() == "#" or line.startswith("# ")):
-                    warnings.warn(
-                        f"Potential unclosed block {block_name!r} detected. "
-                        f"A '# ///' block is needed to indicate the end of the block."
-                    )
-                    # Reset
-                    in_block = False
-                    block_name, block_data = None, []
-                elif line.rstrip() == "# ///":
-                    block_text = "".join(block_data)
-
-                    yield block_name, block_text
-
-                    # Reset blocks
-                    in_block = False
-                    block_name, block_data = None, []
-                else:
-                    if line.startswith("# /// "):
-                        # Possibly an unclosed block. Make note.
-                        invalid_block_name = line[5:].strip()
-                        self.possible_errors.append(
-                            f"New {invalid_block_name!r} block encountered before "
-                            f"block {block_name!r} closed."
-                        )
-
-                    # Append
-                    block_data.append(_removeprefix(line[1:], " "))
-            else:
-                if line.startswith("#"):
-                    line = line.rstrip()
-                    if line != "# ///" and line.startswith("# /// "):
-                        line = _removeprefix(line[1:], " ")
-                        block_name = line[4:].strip()
-                        if block_name in consumed_blocks:
-                            raise ValueError(f"Multiple {block_name!r} blocks found.")
-                        elif block_name == "pyproject.toml":
-                            warnings.warn(f"{block_name!r} block found, should be 'pyproject'.")
-
-                        if _is_valid_type(block_name):
-                            consumed_blocks.add(block_name)
-                            in_block = True
-
-        if in_block:
-            warnings.warn(
-                f"Potential unclosed block {block_name!r} detected. "
-                f"A '# ///' block is needed to indicate the end of the block."
-            )
-
-    def iter_raw_metadata_blocks(self):
-        """
-        Iterator that returns raw metadata blocks.
-
-        :yield: block_name, block_text pairs
-        :ytype: tuple[str, str]
-        """
-        if self.src:
-            data = io.StringIO(self.src)
-            yield from self._parse_source_blocks(data)
-        elif self.src_path:
-            with open(self.src_path, "r", encoding=self.encoding) as data:
-                yield from self._parse_source_blocks(data)
-
-    def get_first_metadata_block(self, name):
-        """
-        Get the text of the first metadata block that matches the 'TYPE' block
-        given by 'name'
-
-        :param name: name of the 'TYPE' block to extract: eg 'pyproject'
-        :type name: str
-        :return: text of the metadata block
-        :rtype: str
-        """
-        for block_name, block_text in self.iter_raw_metadata_blocks():
-            if block_name == name:
-                return block_text
-        raise KeyError(f"{name!r} block not found in file.")
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"metadata={self.blocks!r}, "
+            f"warnings={self.warnings!r}"
+            f")"
+        )
 
     @property
-    def metadata_blocks(self):
+    def pyproject_text(self):
         """
-        Get the text of the metadata blocks as a dictionary.
-
-        :return: Dictionary of block name: toml_text
-        :rtype: dict[str, str]
-        """
-        return {
-            block_name: raw_toml
-            for block_name, raw_toml in self.iter_raw_metadata_blocks()
-        }
-
-    def get_pyproject_raw(self):
-        """
-        Get the text of the pyproject block.
-
-        If no block is found, raise a KeyError.
-
-        Use this if you want to use an external TOML parser for the block or
-        for caching on the text of the block.
-
-        :return: pyproject metadata block text
+        Get the raw text from a 'pyproject' metadata block.
+        :return: text source from pyproject block
         :rtype: str
-        :raises: KeyError if no pyproject block found
         """
-        return self.metadata_blocks["pyproject"]
-
-    def get_pyproject_toml(self):
-        """
-        Get the parsed pyproject block.
-
-        If no block is found, raise a KeyError.
-
-        Use this if you wish to make use of the full 'pyproject' TOML data.
-
-        :return: pyproject toml block parsed into a dict
-        :rtype: dict
-        :raises: KeyError if no pyproject block found
-        """
-        try:
-            return _laz.tomllib.loads(self.get_pyproject_raw())
-        except _laz.tomllib.TOMLDecodeError as e:
-            if self.possible_errors:
-                errs = ",".join(self.possible_errors)
-                raise _laz.tomllib.TOMLDecodeError(
-                    f"{e}; Possible Metadata Syntax Errors: {errs}"
-                )
-            else:
-                raise
-
-    @property
-    def pyproject_raw(self):
-        """
-        Get the text of the pyproject block
-
-        If no block is found, return None.
-
-        Use this if you want to use an external TOML parser for the block or
-        if caching on the text of the block.
-
-        :return: pyproject metadata block text or None
-        :rtype: str | None
-        """
-        try:
-            return self.get_pyproject_raw()
-        except KeyError:
-            return None
+        return self.blocks.get("pyproject", None)
 
     @property
     def pyproject_toml(self):
         """
-        Get the parsed pyproject block.
+        The parsed 'TOML' data from a 'pyproject' metadata block
 
-        If no block is found, return None.
-
-        Use this if you wish to make use of the full 'pyproject' TOML data.
-
-        :return: pyproject toml block parsed into a dict
-        :rtype: dict | None
-        """
-        try:
-            return self.get_pyproject_toml()
-        except KeyError:
-            return None
-
-    @property
-    def plain_script_dependencies(self):
-        """
-        Get the [run] block from the 'pyproject' metadata.
-
-        If there is no pyproject block or [run] table,
-        return None for the python version and an empty list of dependencies.
-
-        Use this if you wish to use a tool other than 'packaging' to handle
-        version specifiers and requirements or if you are caching based on
-        the text of the specified requirements.
-
-        :return: pyproject 'run' table
+        :return: Dictionary of keys and data from the 'pyproject' toml block
         :rtype: dict
         """
-        try:
-            dep_data = self.get_pyproject_toml()
-        except KeyError:
-            run_block = {}
+        if self.pyproject_text is None:
+            return {}
         else:
-            run_block = dep_data.get("run", {})
+            try:
+                return _laz.tomllib.loads(self.pyproject_text)
+            except _laz.tomllib.TOMLDecodeError as e:
+                if self.warnings:
+                    warns = ",".join(self.warnings)
+                    raise _laz.tomllib.TOMLDecodeError(
+                        f"{e}; Possible Metadata Issues: {warns}"
+                    )
+                else:
+                    raise
 
-        if self.PYTHON_VERSION_KEY not in run_block:
-            run_block[self.PYTHON_VERSION_KEY] = None
-        if self.DEPENDENCIES_KEY not in run_block:
-            run_block[self.DEPENDENCIES_KEY] = []
+    @property
+    def run_requirements_text(self):
+        """
+        Requirements data from toml block
+        :return:
+        """
+
+        run_block = self.pyproject_toml.get("run", {})
+        run_block[self.PYTHON_VERSION_KEY] = run_block.get(self.PYTHON_VERSION_KEY, None)
+        run_block[self.DEPENDENCIES_KEY] = run_block.get(self.DEPENDENCIES_KEY, [])
 
         return run_block
 
     @property
-    def script_dependencies(self):
+    def run_requirements(self):
         """
-        Get the requirements as packaging Version and Requirement objects.
-
-        If there is no pyproject block this will return None for the python version
-        and an empty list of dependencies.
-
-        :return: pyproject 'run' table with requires-python and dependencies values
-                 parsed into SpecifierSet and Requirement objects respectively.
-        :rtype: dict
+        Requirements data from toml block
+        :return:
         """
+
         requires_python = None
         dependencies = []
 
-        try:
-            block = self.get_pyproject_toml()
-        except KeyError:
-            run_block = {}
-        else:
-            run_block = block.get("run", {})
+        run_block = self.pyproject_toml.get("run", {})
 
-            pyver = run_block.pop(self.PYTHON_VERSION_KEY, None)
-            if pyver:
-                requires_python = _laz.SpecifierSet(pyver)
+        pyver = run_block.pop(self.PYTHON_VERSION_KEY, None)
+        if pyver:
+            requires_python = _laz.SpecifierSet(pyver)
 
-            deps = run_block.pop(self.DEPENDENCIES_KEY, [])
-            if deps:
-                dependencies = [_laz.Requirement(spec) for spec in deps]
+        deps = run_block.pop(self.DEPENDENCIES_KEY, None)
+        if deps:
+            dependencies = [_laz.Requirement(spec) for spec in deps]
 
         run_block[self.PYTHON_VERSION_KEY] = requires_python
         run_block[self.DEPENDENCIES_KEY] = dependencies
 
         return run_block
+
+
+def _parse_metadata_iterable(iterable_src):
+    """
+    Iterate over source and return embedded metadata.
+
+    :param iterable_src: an iterable of source code: eg an open file
+    :type iterable_src: Iterable[str]
+    :return: EmbeddedMetadata containing data from the source
+    :rtype: EmbeddedMetadata
+    """
+
+    # Is the parser within a potential metadata block
+    in_block = False
+
+    # Has a potential closing '# ///' line been seen for
+    # the current metadata block
+    end_seen = False
+
+    block_name = None
+    block_data = []
+    partial_block_data = []
+
+    metadata = {}
+    warnings_list = []
+
+    for line_no, line in enumerate(iterable_src, start=1):
+        if in_block:
+            if not (line.rstrip() == "#" or line.startswith("# ")):
+                if end_seen:
+                    metadata[block_name] = "".join(block_data)
+                else:
+                    # Warn about potentially unclosed block
+                    message = (
+                        f"Line {line_no}: "
+                        f"Potential unclosed block {block_name!r} detected. "
+                        f"A '# ///' block is needed to indicate the end of the block."
+                    )
+                    warnings_list.append(message)
+
+                # Reset
+                in_block = False
+                block_name, block_data = None, []
+                end_seen = False
+
+            elif line.rstrip() == "# ///":
+                block_data.extend("".join(partial_block_data))
+                end_seen = True
+
+                # reset partial data - add this line
+                partial_block_data = [_removeprefix(line[1:], " ")]
+
+            else:
+                if line.startswith("# /// "):
+                    # Possibly an unclosed block. Make note.
+                    invalid_block_name = line[5:].strip()
+                    warnings_list.append(
+                        f"Line {line_no}: "
+                        f"New {invalid_block_name!r} block encountered before "
+                        f"block {block_name!r} closed."
+                    )
+
+                # Append
+                partial_block_data.append(_removeprefix(line[1:], " "))
+        else:
+            if line.startswith("#"):
+                line = line.rstrip()
+
+                if line != "# ///" and line.startswith("# /// "):
+                    line = _removeprefix(line[1:], " ")
+                    block_name = line[4:].strip()
+
+                    # Fair chance people will try to call the block
+                    # 'pyproject.toml', warn in that case
+                    if block_name == "pyproject.toml":
+                        warnings_list.append(
+                            f"Line {line_no}: "
+                            f"{block_name!r} block found, should be 'pyproject'."
+                        )
+
+                    if _is_valid_type(block_name):
+                        if block_name in metadata:
+                            raise ValueError(f"Line {line_no}: Duplicate {block_name!r} block found.")
+                        in_block = True
+                    else:
+                        # Not valid type, remove block name
+                        block_name = None
+    if in_block:
+        if end_seen:
+            metadata[block_name] = "".join(block_data)
+        else:
+            warnings_list.append(
+                f"End of File: "
+                f"Potential unclosed block {block_name!r} detected. "
+                f"A '# ///' block is needed to indicate the end of the block."
+            )
+
+    return EmbeddedMetadata(blocks=metadata, warnings=warnings_list)
+
+
+def metadata_from_path(source_path, encoding="utf-8"):
+    """
+    Extract embedded metadata from a given python source file path
+
+    :param source_path: Path to the python source file
+    :type source_path: str | os.PathLike
+    :param encoding: text encoding of source file
+    :type encoding: str
+    :return: metadata block
+    :rtype: EmbeddedMetadata
+    """
+    with open(source_path, encoding=encoding) as src_file:
+        metadata = _parse_metadata_iterable(src_file)
+    return metadata
+
+
+def metadata_from_string(source_string):
+    """
+    Extract embedded metadata from python source code given as a string
+
+    :param source_string: Python source code as string
+    :type source_string: str
+    :return: metadata block
+    :rtype: EmbeddedMetadata
+    """
+    return _parse_metadata_iterable(io.StringIO(source_string))

--- a/src/ducktools/pep723parser.py
+++ b/src/ducktools/pep723parser.py
@@ -49,12 +49,12 @@ def _is_valid_type(txt):
     return all(c in valid_type for c in txt)
 
 
-class PEP723Parser:
+class EmbeddedMetadataParser:
     """
-    Parse PEP723 metadata blocks.
+    Parse embedded metadata blocks.
 
     This provides methods and properties to assist in handling
-    PEP723 metadata blocks.
+    embedded metadata blocks.
 
     get_* methods will raise a KeyError exception if the block is not found
     properties will instead return None if the block is not found
@@ -80,24 +80,24 @@ class PEP723Parser:
     @classmethod
     def from_path(cls, src_path, encoding="utf-8"):
         """
-        Create a PEP723Parser instance given the path to a source file
+        Create an EmbeddedMetadataParser instance given the path to a source file
 
-        :param src_path: path to a python source file to search for PEP723 metadata
+        :param src_path: path to a python source file to search for embedded metadata
         :type src_path: str | os.PathLike
         :param encoding: encoding to use when opening the file.
         :type encoding: str
-        :return: PEP723Parser instance
+        :return: EmbeddedMetadataParser instance
         """
         return cls(src_path=src_path, encoding=encoding)
 
     @classmethod
     def from_string(cls, src):
         """
-        Create a PEP723Parser instance given source code as a string
+        Create a EmbeddedMetadataParser instance given source code as a string
 
-        :param src: source code to search for PEP723 metadata.
+        :param src: source code to search for embedded metadata.
         :type src: str
-        :return: PEP723Parser instance
+        :return: EmbeddedMetadataParser instance
         """
         return cls(src=src)
 
@@ -171,7 +171,7 @@ class PEP723Parser:
 
     def iter_raw_metadata_blocks(self):
         """
-        Iterator that returns raw PEP723 metadata blocks.
+        Iterator that returns raw metadata blocks.
 
         :yield: block_name, block_text pairs
         :ytype: tuple[str, str]
@@ -244,7 +244,7 @@ class PEP723Parser:
             if self.possible_errors:
                 errs = ",".join(self.possible_errors)
                 raise _laz.tomllib.TOMLDecodeError(
-                    f"{e}; Possible PEP723 Errors: {errs}"
+                    f"{e}; Possible Metadata Syntax Errors: {errs}"
                 )
             else:
                 raise

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -2,16 +2,16 @@ from pathlib import Path
 
 import pytest
 
-from ducktools.pep723parser import PEP723Parser
+from ducktools.pep723parser import EmbeddedMetadataParser
 import test_data
 
 
 def get_parser(path, parse_type):
     path = Path(path)
     if parse_type == "string":
-        return PEP723Parser.from_string(path.read_text())
+        return EmbeddedMetadataParser.from_string(path.read_text())
     elif parse_type == "path":
-        return PEP723Parser.from_path(path)
+        return EmbeddedMetadataParser.from_path(path)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -2,28 +2,27 @@ from pathlib import Path
 
 import pytest
 
-from ducktools.pep723parser import EmbeddedMetadataParser
+from ducktools.pep723parser import metadata_from_path, metadata_from_string
 import test_data
 
 
 def get_parser(path, parse_type):
     path = Path(path)
     if parse_type == "string":
-        return EmbeddedMetadataParser.from_string(path.read_text())
+        return metadata_from_string(path.read_text())
     elif parse_type == "path":
-        return EmbeddedMetadataParser.from_path(path)
+        return metadata_from_path(path)
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("parser_type", ["string", "path"])
 @pytest.mark.parametrize("module_name", dir(test_data))
 def test_compliance(parser_type, module_name):
     module = getattr(test_data, module_name)
-    parser = get_parser(module.__file__, parser_type)
     try:
-        metadata = parser.metadata_blocks
+        parser = get_parser(module.__file__, parser_type)
     except Exception as e:
         assert module.is_error
         assert type(e) is type(module.exact_error) and e.args == module.exact_error.args
     else:
+        metadata = parser.blocks
         assert metadata == module.output

--- a/tests/test_data/multiple_blocks_joined.py
+++ b/tests/test_data/multiple_blocks_joined.py
@@ -21,9 +21,14 @@ output = {
         run.dependencies = [
             "ducktools-lazyimporter>=0.1.1",
         ]
+        ///
+        
+        Middle Comment
+        
+        /// newblock
+        newblock data
         """
     ).lstrip(),
-    "newblock": "newblock data\n",
 }
 
 is_error = False

--- a/tests/test_data/multiple_closing_lines.py
+++ b/tests/test_data/multiple_closing_lines.py
@@ -12,6 +12,8 @@ output = {
         """
         [run]
         dependencies = ["requests"]
+        ///
+        Additional comment
         """
     ).lstrip()
 }

--- a/tests/test_data/repeated_block_error.py
+++ b/tests/test_data/repeated_block_error.py
@@ -20,4 +20,4 @@ output = {}
 is_error = True
 
 # Internal
-exact_error = ValueError(f"Multiple 'pyproject' blocks found.")
+exact_error = ValueError("Line 10: Duplicate 'pyproject' block found.")

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,8 @@
-from ducktools.pep723parser import EmbeddedMetadataParser, _is_valid_type
+from ducktools.pep723parser import (
+    metadata_from_string,
+    metadata_from_path,
+    _is_valid_type,
+)
 from pathlib import Path
 from packaging.specifiers import SpecifierSet
 from packaging.requirements import Requirement
@@ -23,9 +27,9 @@ pep_723_ex_extracted_dict = {
     }
 }
 
-pep_723_plain_script_dependencies = pep_723_ex_extracted_dict["run"]
+pep_723_run_requirements_text = pep_723_ex_extracted_dict["run"]
 
-pep_723_script_dependencies = {
+pep_723_run_requirements = {
     "requires-python": SpecifierSet(">=3.11"),
     "dependencies": [
         Requirement("requests<3"),
@@ -38,37 +42,37 @@ class TestParsePEPExample:
     @property
     def file_parser(self):
         test_file = example_folder / "pep-723-sample.py"
-        return EmbeddedMetadataParser.from_path(test_file)
+        return metadata_from_path(test_file)
 
     @property
     def str_parser(self):
         test_file = example_folder / "pep-723-sample.py"
         test_text = test_file.read_text()
-        return EmbeddedMetadataParser.from_string(test_text)
+        return metadata_from_string(test_text)
 
     @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
     def test_pep_example_file_toml(self, parser_type):
         parser = getattr(self, parser_type)
-        output = parser.get_pyproject_toml()
+        output = parser.pyproject_toml
         assert output == pep_723_ex_extracted_dict
 
     @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
-    def test_pep_example_file_plain_script_dependencies(self, parser_type):
+    def test_pep_example_run_requirements_text(self, parser_type):
         parser = getattr(self, parser_type)
-        output = parser.plain_script_dependencies
-        assert output == pep_723_plain_script_dependencies
+        output = parser.run_requirements_text
+        assert output == pep_723_run_requirements_text
 
     @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
-    def test_pep_example_file_script_dependencies(self, parser_type):
+    def test_pep_example_run_requirements(self, parser_type):
         parser = getattr(self, parser_type)
-        output = parser.script_dependencies
-        assert output == pep_723_script_dependencies
+        output = parser.run_requirements
+        assert output == pep_723_run_requirements
 
 
 class TestRaises:
     def test_new_block_without_close(self):
         test_file = example_folder / "valid_but_errors_double_block.py"
-        parser = EmbeddedMetadataParser.from_path(test_file)
+        parser = metadata_from_path(test_file)
 
         # Fails TOML parse
         with pytest.raises(tomllib.TOMLDecodeError):
@@ -76,93 +80,71 @@ class TestRaises:
 
     def test_block_not_closed(self):
         test_file = example_folder / "pep-723-sample-noclose.py"
-        parser = EmbeddedMetadataParser.from_path(test_file)
-        with pytest.warns(UserWarning):
-            _ = parser.script_dependencies
+        parser = metadata_from_path(test_file)
+        assert len(parser.warnings) > 0
+        assert "Potential unclosed block" in parser.warnings[0]
 
     def test_block_not_closed_eof(self):
         test_file = example_folder / "pep-723-sample-noclose-eof.py"
-        parser = EmbeddedMetadataParser.from_path(test_file)
-        with pytest.warns(UserWarning):
-            _ = parser.script_dependencies
+        parser = metadata_from_path(test_file)
+
+        assert len(parser.warnings) > 0
+        assert "Potential unclosed block" in parser.warnings[0]
 
     def test_repeated_block(self):
         test_file = example_folder / "invalid_repeated_block.py"
-        parser = EmbeddedMetadataParser.from_path(test_file)
 
         with pytest.raises(ValueError):
-            _ = parser.metadata_blocks
-
-        with pytest.raises(ValueError):
-            _ = list(parser.iter_raw_metadata_blocks())
+            _ = metadata_from_path(test_file)
 
 
 class TestMissing:
     @property
     def parser(self):
         test_file = example_folder / "example_no_pyproject_block.py"
-        return EmbeddedMetadataParser.from_path(test_file)
-
-    def test_missing_errors(self):
-        parser = self.parser
-
-        with pytest.raises(KeyError):
-            _ = parser.get_first_metadata_block("Missing")
-
-        with pytest.raises(KeyError):
-            _ = parser.get_pyproject_raw()
-
-        with pytest.raises(KeyError):
-            _ = parser.get_pyproject_toml()
+        return metadata_from_path(test_file)
 
     def test_missing_none(self):
         parser = self.parser
 
-        assert parser.pyproject_raw is None
-        assert parser.pyproject_toml is None
+        assert parser.pyproject_text is None
+        assert parser.pyproject_toml == {}
 
     def test_missing_empty(self):
         parser = self.parser
 
-        assert parser.script_dependencies == {
+        assert parser.run_requirements == {
             "requires-python": None,
             "dependencies": [],
         }
 
 
 class TestSpec:
-    # Test that matches the text of the spec but not the regex
-    # as of 23-Oct-2023
+    # Test that matches the updated spec
     def test_multi_block(self):
         test_file = example_folder / "multi_block_discrepency.py"
-        parser = EmbeddedMetadataParser.from_path(test_file)
+        parser = metadata_from_path(test_file)
 
         output_text_pyproject = (
-            "run.dependencies = [\n" '    "ducktools-lazyimporter>=0.1.1",\n' "]\n"
+            'run.dependencies = [\n'
+            '    "ducktools-lazyimporter>=0.1.1",\n'
+            ']\n'
+            '///\n'
+            '\n'
+            'Middle Comment\n'
+            '\n'
+            '/// newblock\n'
+            'newblock data\n'
         )
-        output_text_newblock = "newblock data\n"
 
-        assert parser.metadata_blocks["pyproject"] == output_text_pyproject
-        assert parser.metadata_blocks["newblock"] == output_text_newblock
+        assert parser.pyproject_text == output_text_pyproject
 
 
 def test_toml_extension_warning():
     test_file = example_folder / "toml_warning.py"
-    parser = EmbeddedMetadataParser.from_path(test_file)
+    parser = metadata_from_path(test_file)
 
-    with pytest.warns(
-            UserWarning,
-            match="'pyproject.toml' block found, should be 'pyproject'."
-    ):
-        _ = parser.metadata_blocks
-
-
-def test_invalid_parser_init():
-    with pytest.raises(ValueError):
-        _ = EmbeddedMetadataParser()
-
-    with pytest.raises(ValueError):
-        _ = EmbeddedMetadataParser(src="Code", src_path="path/to/file")
+    assert "'pyproject.toml' block found, should be 'pyproject'." in parser.warnings[0]
 
 
 def test_valid_types():

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,4 @@
-from ducktools.pep723parser import PEP723Parser, _is_valid_type
+from ducktools.pep723parser import EmbeddedMetadataParser, _is_valid_type
 from pathlib import Path
 from packaging.specifiers import SpecifierSet
 from packaging.requirements import Requirement
@@ -38,13 +38,13 @@ class TestParsePEPExample:
     @property
     def file_parser(self):
         test_file = example_folder / "pep-723-sample.py"
-        return PEP723Parser.from_path(test_file)
+        return EmbeddedMetadataParser.from_path(test_file)
 
     @property
     def str_parser(self):
         test_file = example_folder / "pep-723-sample.py"
         test_text = test_file.read_text()
-        return PEP723Parser.from_string(test_text)
+        return EmbeddedMetadataParser.from_string(test_text)
 
     @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
     def test_pep_example_file_toml(self, parser_type):
@@ -68,7 +68,7 @@ class TestParsePEPExample:
 class TestRaises:
     def test_new_block_without_close(self):
         test_file = example_folder / "valid_but_errors_double_block.py"
-        parser = PEP723Parser.from_path(test_file)
+        parser = EmbeddedMetadataParser.from_path(test_file)
 
         # Fails TOML parse
         with pytest.raises(tomllib.TOMLDecodeError):
@@ -76,19 +76,19 @@ class TestRaises:
 
     def test_block_not_closed(self):
         test_file = example_folder / "pep-723-sample-noclose.py"
-        parser = PEP723Parser.from_path(test_file)
+        parser = EmbeddedMetadataParser.from_path(test_file)
         with pytest.warns(UserWarning):
             _ = parser.script_dependencies
 
     def test_block_not_closed_eof(self):
         test_file = example_folder / "pep-723-sample-noclose-eof.py"
-        parser = PEP723Parser.from_path(test_file)
+        parser = EmbeddedMetadataParser.from_path(test_file)
         with pytest.warns(UserWarning):
             _ = parser.script_dependencies
 
     def test_repeated_block(self):
         test_file = example_folder / "invalid_repeated_block.py"
-        parser = PEP723Parser.from_path(test_file)
+        parser = EmbeddedMetadataParser.from_path(test_file)
 
         with pytest.raises(ValueError):
             _ = parser.metadata_blocks
@@ -101,7 +101,7 @@ class TestMissing:
     @property
     def parser(self):
         test_file = example_folder / "example_no_pyproject_block.py"
-        return PEP723Parser.from_path(test_file)
+        return EmbeddedMetadataParser.from_path(test_file)
 
     def test_missing_errors(self):
         parser = self.parser
@@ -135,7 +135,7 @@ class TestSpec:
     # as of 23-Oct-2023
     def test_multi_block(self):
         test_file = example_folder / "multi_block_discrepency.py"
-        parser = PEP723Parser.from_path(test_file)
+        parser = EmbeddedMetadataParser.from_path(test_file)
 
         output_text_pyproject = (
             "run.dependencies = [\n" '    "ducktools-lazyimporter>=0.1.1",\n' "]\n"
@@ -148,7 +148,7 @@ class TestSpec:
 
 def test_toml_extension_warning():
     test_file = example_folder / "toml_warning.py"
-    parser = PEP723Parser.from_path(test_file)
+    parser = EmbeddedMetadataParser.from_path(test_file)
 
     with pytest.warns(
             UserWarning,
@@ -159,10 +159,10 @@ def test_toml_extension_warning():
 
 def test_invalid_parser_init():
     with pytest.raises(ValueError):
-        _ = PEP723Parser()
+        _ = EmbeddedMetadataParser()
 
     with pytest.raises(ValueError):
-        _ = PEP723Parser(src="Code", src_path="path/to/file")
+        _ = EmbeddedMetadataParser(src="Code", src_path="path/to/file")
 
 
 def test_valid_types():

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,4 @@
-from ducktools.pep723parser import PEP723Parser
+from ducktools.pep723parser import PEP723Parser, _is_valid_type
 from pathlib import Path
 from packaging.specifiers import SpecifierSet
 from packaging.requirements import Requirement
@@ -163,3 +163,13 @@ def test_invalid_parser_init():
 
     with pytest.raises(ValueError):
         _ = PEP723Parser(src="Code", src_path="path/to/file")
+
+
+def test_valid_types():
+    assert _is_valid_type("pyproject")
+    assert _is_valid_type("test-example123")
+    assert _is_valid_type("123test-example")
+    assert not _is_valid_type("example_with_underscores")
+    assert not _is_valid_type("pyproject.toml")
+    assert not _is_valid_type("random$extra!characters")
+    assert not _is_valid_type("\"internalquotes\"")


### PR DESCRIPTION
Tighten up the parsing rules to more closely match the regex.

Change the API to parse early and not allow two variations of `__init__` usage.

Remove most specific PEP references. Eventually the readme will link to the packaging docs.